### PR TITLE
SQL docs: COPY TO statement

### DIFF
--- a/website/docs/sql/command/copy_to.md
+++ b/website/docs/sql/command/copy_to.md
@@ -1,0 +1,118 @@
+# COPY TO
+
+— copy data from a table to a file
+
+## Synopsis
+
+```sql_template
+COPY { <table_name> [ (<column_name> [, ...] ) ] | ( <query> ) }
+  TO <target_location>
+  [ WITH (<option> [, ...]) ]
+```
+
+where `<option>` can be one of:
+
+```sql_template
+FORMAT => <format_name>
+<format_specific_option> => <value>
+```
+
+## Description
+
+`COPY TO` copies the content of a Hyper database table to one or
+more files, overriding existing files if there is any.
+
+If a column list is specified, only those specified columns will
+be written, in the order they appear in the column list.
+
+Depending on the target location, Hyper will write data, e.g., to a
+local file, an AWS S3 bucket or standard output. More information
+on the available locations can be found in [External Locations](/docs/sql/external/location).
+
+## Parameters
+
+`<table_name>`
+
+:   The name (optionally database- or schema-qualified) of an existing
+    table.
+
+`<column_name>`
+
+:   An optional list of columns to be copied. If no column list is
+    specified, all columns of the table will be copied.
+
+`<query>`
+
+:   A [SELECT](select) command in any of its forms (`SELECT`, `TABLE`,
+    or `VALUES`).
+
+`<target_location>`
+
+: Location to write the data to. See [External Location](/docs/sql/external/location)
+  documentation for more information.
+
+`FORMAT => format_name`
+
+:   Selects the data format to be read. This option can be omitted in
+    case the format can be inferred from the file extension. In case of
+    a list of targets, all of them need to share this extension.
+    Supported formats are depicted in detail in
+    [External formats](/docs/sql/external/formats).
+
+`format_specific_option => value`
+
+:   A format-specific option. The available options for each respective
+    format can be found in [External formats](/docs/sql/external/formats).
+
+## Examples {#sql-copy-examples}
+
+Copy a table to a CSV file in the working directory of the Hyper server,
+having a custom delimiter. The schema of the CSV file will be the same
+as the schema of the table `products`:
+
+    COPY products TO './products.csv' WITH ( FORMAT => 'csv', DELIMITER => '|' )
+
+Same but writing to multiple CSV files (assume the table `products` is
+large enough so that the resulting CSV file will be larger than 500000
+bytes):
+
+    COPY products to './products.csv'
+    WITH ( FORMAT => 'csv', max_file_size => 500000 )
+
+Copy to an Apache Parquet file to Amazon S3 using empty credentials and
+inferring the bucket region. The file format is inferred from the file
+extension:
+
+    COPY products TO s3_location(
+        's3://mybucket/mydirectory/products.parquet',
+        access_key_id => '',
+        secret_access_key => ''
+    )
+
+Same but with explicit Amazon S3 credentials and bucket region:
+
+    COPY products
+    TO s3_location(
+        's3://mybucket/mydirectory/products.parquet',
+        access_key_id => 'ACCESSKEYID12EXAMPLE',
+        secret_access_key => 'sWfssWSmnME5X/36dsf3G/cbyDzErEXAMPLE123',
+        region => 'us-east-1'
+    )
+
+## Notes
+
+Files named in a `COPY` command are read directly by the server, not by
+the client application. Therefore, they must reside on or be accessible
+to the database server machine, not the client. They must be accessible
+to and readable by the Hyper user (the user ID the server runs as), not
+the client.
+
+`COPY` input and output is affected by [date_style](#date_style).
+
+`COPY` stops operation at the first error.
+
+Hyper also supports the PostgreSQL syntax of the `COPY` command, which
+is slightly different from the syntax depicted here. This is only
+supported for PostgreSQL compatibility. When writing SQL for Hyper, we
+recommend using the syntax documented here.
+

--- a/website/docs/sql/external/formats.md
+++ b/website/docs/sql/external/formats.md
@@ -7,20 +7,20 @@ Parquet) while others do not (e.g., CSV). While Hyper can infer
 the schema of formats possessing schema information automatically,
 the schema has to be given explicitly for formats without schema
 information (or is taken from the target table in a
-[COPY](/docs/sql/command/copy_from) statement).
+[COPY FROM](/docs/sql/command/copy_from) statement).
 
-The format of an external source is set through the
+The format of an external source or target is set through the
 `FORMAT` option. If the `FORMAT` option is not
 specified, Hyper will try to infer the format from the file extension.
-If multiple files are read, all have to possess the same extension for
-the inferral to succeed.
+If multiple files are read or written, all have to possess the same
+extension for the inferral to succeed.
 
 The following formats are supported:
 
 Format |`format` Option Value |Recognized File Extensions |Schema Inference? |Description
 ----|----|----|----|----
-[Text](#external-format-text) |`'text'` |`.csv`, `.csv.gz` |No |Text format; as in PostgreSQL. Optionally, gzip compressed.
-[CSV](#external-format-csv) |`'csv'` | |No |Comma Separated Value format; as in PostgreSQL. Optionally, gzip compressed.
+[Text](#external-format-text) |`'text'` |`.txt`, `.txt.gz` |No |Text format; as in PostgreSQL. Optionally, gzip compressed (currently not supported by [COPY TO](/docs/sql/command/copy_to)).
+[CSV](#external-format-csv) |`'csv'` |`.csv`, `.csv.gz` |No |Comma Separated Value format; as in PostgreSQL. Optionally, gzip compressed (currently not supported by [COPY TO](/docs/sql/command/copy_to)).
 [Apache Parquet](#external-format-parquet) |`'parquet'` |`.parquet` |Yes |The [Apache Parquet format](https://parquet.apache.org/); both version 1 and 2 supported
 [Apache Iceberg](#external-format-iceberg) |`'iceberg'` |Specified path must point to table directory |Yes |The [Apache Iceberg format](https://iceberg.apache.org/); version 1 and 2 are supported; version 3 is not supported
 
@@ -29,13 +29,13 @@ Format |`format` Option Value |Recognized File Extensions |Schema Inference? |De
 Format options allow customizing the way the external format is read and
 interpreted. The available options depend on the format. Syntactically,
 options are specified using the syntax for named parameters, that is,
-`option => value`, and separated by commas. In the [COPY FROM](../command/copy_from)
-and [CREATE EXTERNAL TABLE](../command/create_external_table) statement,
-options are specified in the `WITH` clause. For the
+`option => value`, and separated by commas. In the [COPY FROM](../command/copy_from),
+[COPY TO](../command/copy_to) and [CREATE EXTERNAL TABLE](../command/create_external_table)
+statement, options are specified in the `WITH` clause. For the
 [`external`](../setreturning#external) function, options are specified
-as function arguments after the initial argument describing the source.
-For example, the following statements all read from a CSV file `products.csv`,
-using field delimiter `'|'`:
+as function arguments after the initial argument describing the source
+or target. For example, the following statements all read from a CSV
+file `products.csv`, using field delimiter `'|'`:
 
 ```
 COPY products FROM 'products.csv' WITH (FORMAT => 'csv', DELIMITER => '|');
@@ -90,9 +90,15 @@ The following options are available for all or multiple external formats:
   compression internally, so gzipping a Parquet file is not advisable
   and therefore not used in practice.
 
+`MAX_FILE_SIZE => integer`
+
+: If set, the `COPY TO` statement will write to multiple files, each of
+  size specified by `MAX_FILE_SIZE`, with the exception of the last
+  file.
+
 ## Text Format {#external-format-text}
 
-When the `FORMAT => 'text'` option is used, the data is read as a text
+When the `FORMAT => 'text'` option is used, the data is read or written as a text
 file with one line per table row. Columns in a row are separated by the
 delimiter character. The column values are string representations of the
 values, as if the values were casted to the `text` type. The specified
@@ -260,8 +266,7 @@ location with limited bandwidth, such as when accessing Amazon S3 from a
 non-AWS machine.
 
 The Apache Parquet format stores schema information, so Hyper can infer
-the schema for Parquet files. The only options supported by this format
-are the [common format options](#common-format-options).
+the schema for Parquet files.
 
 Hyper supports both versions v1 and v2 of Parquet, including the
 DataPageV2 page format. However, some data types, encodings, and
@@ -295,6 +300,24 @@ If a Parquet file contains columns with unsupported data types or
 encodings, Hyper can still read the other columns in the file, as long
 as you do not select any unsupported columns.
 :::
+
+Besides the [common format options](#common-format-options), the
+following options are available when writing to Parquet files:
+
+`ROWS_PER_ROW_GROUP => integer`
+
+: The number of rows to include in a row group.
+
+`CODEC => { 'uncompressed' | 'snappy' | 'gzip' | 'zstd' | 'lz4_raw' }`
+
+: Options to compress the data.
+
+`WRITE_STATISTICS => { 'none' | 'rowgroup' | 'page' | 'columnindex' }`
+
+: Whether or how the statistics should be written. `rowgroup` means to
+  write row group statistics only. `page` means to write row group and
+  page statistics. `columnindex` means to write row group, column and
+  offset statistics, without page statistics.
 
 ## Apache Iceberg Format {#external-format-iceberg}
 

--- a/website/docs/sql/external/index.md
+++ b/website/docs/sql/external/index.md
@@ -1,8 +1,8 @@
 # External Formats
 
-Besides its own table format, Hyper is able to access data stored in
-other commonly used data formats (called external formats or external
-data hereinafter).
+Besides its own table format, Hyper is able to read and write data
+stored in other commonly used data formats (called external formats or
+external data hereinafter).
 
 There are three orthogonal concepts when it comes to external formats:
 
@@ -13,7 +13,7 @@ There are three orthogonal concepts when it comes to external formats:
   corresponding options, such as the credentials to use when connecting to
   S3. See [External Locations](location) for more details.
 * What to do with the external data. E.g., there are multiple syntactic
-  options to [read external data](syntax).
+  options to [read external data](syntax) or [write data](../command/copy_to)
 
 ```mdx-code-block
 import DocCardList from '@theme/DocCardList';

--- a/website/docs/sql/external/syntax.md
+++ b/website/docs/sql/external/syntax.md
@@ -32,6 +32,7 @@ has the same columns as the existing table `products`:
 
 ```
 COPY products FROM 'products.parquet';
+
 INSERT INTO products (SELECT * FROM external('products.parquet'))
 ```
 
@@ -64,7 +65,7 @@ fill a products table:
 CREATE TABLE products AS (SELECT * FROM external('products.parquet'))
 ```
 
-## Creating External Tables vs. Using Ad-hoc Queryies
+## Creating External Tables vs. Using Ad-hoc Queries
 
 The set returning function `external` and the
 `CREATE TEMPORARY EXTERNAL TABLE` statement can both be used to query

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -54,6 +54,7 @@ const sidebars = {
             'sql/command/delete',
             'sql/command/truncate',
             'sql/command/copy_from',
+            'sql/command/copy_to',
             'sql/command/create_database',
             'sql/command/create_schema',
             'sql/command/create_table',


### PR DESCRIPTION
Hyper is officially supporting the `COPY TO` statement. This commit adds documentation for this statement and related format information