### PR TITLE
Document that we prefer the `.hyper` file extension

### DIFF
--- a/website/docs/guides/hyper_file/create_update.md
+++ b/website/docs/guides/hyper_file/create_update.md
@@ -41,7 +41,7 @@ with HyperProcess(Telemetry.SEND_USAGE_DATA_TO_TABLEAU,
 The script consist of 3 high-level steps:
 
 1. Start a Hyper process. The [`HyperProcess`](../../hyper-api/hyper_process)
-2. Create a connection to the `.hyper` file. Since we create the [`Connection`](../../hyper-api/connection) class with the `CreateMode.CREATE_AND_REPLACE`, the `.hyper` will be automatically created if doesn't exist yet, and will be overwritten if a file with that name already exists.
+2. Create a connection to the `.hyper` file. Since we create the [`Connection`](../../hyper-api/connection) class with the `CreateMode.CREATE_AND_REPLACE`, the `.hyper` file will be automatically created if it does not exist yet, and will be overwritten if a file with that name already exists.
 3. Defining the table. In this case, we are using the Python utilities `TableDefinition` and `catalog.create_table`. We could have also used a [CREATE TABLE](../../sql/command/create_table) SQL command.
 4. Insert the data. In the example, we use the `Inserter` utility to provide the data from Python. You can also use [INSERT](../../sql/command/insert) or [COPY](../../sql/command/copy_from) statements or any other means to load data into the table. E.g., you can thereby directly load your table from a CSV file.
 

--- a/website/docs/guides/hyper_file/create_update.md
+++ b/website/docs/guides/hyper_file/create_update.md
@@ -41,7 +41,7 @@ with HyperProcess(Telemetry.SEND_USAGE_DATA_TO_TABLEAU,
 The script consist of 3 high-level steps:
 
 1. Start a Hyper process. The [`HyperProcess`](../../hyper-api/hyper_process)
-2. Create a connection to the `.hyper` file. Since we create the [`Connection` class](../../hyper-api/connection) class with the `CreateMode.CREATE_AND_REPLACE`, the `.hyper` will be automatically created if doesn't exist yet, and will be overwritten if a file with that name already exists.
+2. Create a connection to the `.hyper` file. Since we create the [`Connection`](../../hyper-api/connection) class with the `CreateMode.CREATE_AND_REPLACE`, the `.hyper` will be automatically created if doesn't exist yet, and will be overwritten if a file with that name already exists.
 3. Defining the table. In this case, we are using the Python utilities `TableDefinition` and `catalog.create_table`. We could have also used a [CREATE TABLE](../../sql/command/create_table) SQL command.
 4. Insert the data. In the example, we use the `Inserter` utility to provide the data from Python. You can also use [INSERT](../../sql/command/insert) or [COPY](../../sql/command/copy_from) statements or any other means to load data into the table. E.g., you can thereby directly load your table from a CSV file.
 

--- a/website/docs/hyper-api/connection.md
+++ b/website/docs/hyper-api/connection.md
@@ -42,6 +42,14 @@ with HyperProcess(telemetry=Telemetry.SEND_USAGE_DATA_TO_TABLEAU) as hyper:
         print(connection.execute_scalar_query('SELECT COUNT(*) FROM "my_table"'))
 ```
 
+:::tip Hyper file extension
+
+While Hyper itself allows database files with arbitrary file extensions, we highly
+recommend using the `.hyper` file extension. This is also the only file extension
+under which Hyper files are supported in Tableau products.
+
+:::
+
 In addition, the `CreateMode` specifies how Hyper should react if the given Hyper file does not exist:
 
 Mode  | Behavior


### PR DESCRIPTION
So far, Hyper API internally enforced that all opened Hyper database
files use the `.hyper` file extension. We removed this restriction
from Hyper API. Clarify in the documentation, that `.hyper` is still
the preferred file extensions.
