### PR TITLE
Rename fiscal calendar options

### DIFF
--- a/website/docs/releases.md
+++ b/website/docs/releases.md
@@ -24,6 +24,10 @@ In case you are wondering why all our releases start with `0.0`, read [this FAQ 
 ### Upcoming Release
 
 * .Net Deprecation: As announced last release, we are deprecating the .NET version of Hyper API. We decided to [open-source its source code](https://github.com/tableau/hyper-api-dotnet), so whoever might be interested in maintaining it can pick up where we left.
+* Some of the [Fiscal Calendar Options](/docs/sql/scalar_func/datetime#fiscal-calendar-options) were renamed:
+  * `start_month` was renamed to `fiscal_year_start_month`.
+  * `first_day_of_week` was renamed to `first_day_of_fiscal_week`.
+* The [EXTRACT](/docs/sql/scalar_func/datetime#datetime-extract) function was accepting (and ignoring) named arguments which were not required. Now it only accepts [Fiscal Calendar Options](/docs/sql/scalar_func/datetime#fiscal-calendar-options) when fiscal function fields are used. A named argument which is not required by the [EXTRACT](/docs/sql/scalar_func/datetime#datetime-extract) function will be rejected.
 
 ### 0.0.17782 [September 6nd, 2023]
 

--- a/website/docs/releases.md
+++ b/website/docs/releases.md
@@ -24,9 +24,9 @@ In case you are wondering why all our releases start with `0.0`, read [this FAQ 
 ### Upcoming Release
 
 * .Net Deprecation: As announced last release, we are deprecating the .NET version of Hyper API. We decided to [open-source its source code](https://github.com/tableau/hyper-api-dotnet), so whoever might be interested in maintaining it can pick up where we left.
-* Some of the [Fiscal Calendar Options](/docs/sql/scalar_func/datetime#fiscal-calendar-options) were renamed:
-  * `start_month` was renamed to `fiscal_year_start_month`.
-  * `first_day_of_week` was renamed to `first_day_of_fiscal_week`.
+* Some of the [Fiscal Calendar Options](/docs/sql/scalar_func/datetime#fiscal-calendar-options) are renamed:
+  * `start_month` is renamed to `fiscal_year_start_month`.
+  * `first_day_of_week` is renamed to `first_day_of_fiscal_week`.
 * The [EXTRACT](/docs/sql/scalar_func/datetime#datetime-extract) function was accepting (and ignoring) named arguments which were not required. Now it only accepts [Fiscal Calendar Options](/docs/sql/scalar_func/datetime#fiscal-calendar-options) when fiscal function fields are used. A named argument which is not required by the [EXTRACT](/docs/sql/scalar_func/datetime#datetime-extract) function will be rejected.
 
 ### 0.0.17782 [September 6nd, 2023]

--- a/website/docs/sql/scalar_func/datetime.md
+++ b/website/docs/sql/scalar_func/datetime.md
@@ -486,7 +486,7 @@ Examples (assuming the local time zone is `America/New_York`):
     SELECT date_trunc('day', TIMESTAMP WITH TIME ZONE '2001-02-16 20:38:40+00');
     Result: 2001-02-16 00:00:00-05
 
-    SELECT date_trunc('fiscal_year', TIMESTAMP '2001-02-16 20:38:40', start_month => 2, use_start_date_as_fiscal_year_name => false);
+    SELECT date_trunc('fiscal_year', TIMESTAMP '2001-02-16 20:38:40', fiscal_year_start_month => 2);
     Result: 2001-02-01 00:00:00
 
 ## Current Date/Time {#datetime-current}
@@ -552,11 +552,11 @@ fiscal_year
 
 The following fiscal calendar options are available:
 
-`start_month => <value>`
+`fiscal_year_start_month => <value>`
 :   The month in which the fiscal year starts. If the fiscal year starts
     in February, `<value>` should be `2`. The default value is `1` (January).
 
-`first_day_of_week => <value>`
+`first_day_of_fiscal_week => <value>`
 :   The first day of the fiscal week. If the fiscal year starts with
     January, and `<value>` is `1` (Monday), `fiscal_week` on date
     (timestamp) `2023-01-02` will return `2`, since `2023-01-01` is a
@@ -571,10 +571,10 @@ The following fiscal calendar options are available:
 
 Some examples:
 
-    SELECT EXTRACT(fiscal_week FROM timestamp '2000-01-02 20:38:40', first_day_of_week => 7);
+    SELECT EXTRACT(fiscal_week FROM timestamp '2000-01-02 20:38:40', first_day_of_fiscal_week => 7);
     Result: 2
 
-    SELECT EXTRACT(fiscal_year FROM timestamp '2000-02-16 20:38:40', start_month => 3);
+    SELECT EXTRACT(fiscal_year FROM timestamp '2000-02-16 20:38:40', fiscal_year_start_month => 3);
     Result: 1999
 
     SELECT EXTRACT(fiscal_year FROM timestamp '2000-02-16 20:38:40', use_start_date_as_fiscal_year_name => false);


### PR DESCRIPTION
`start_month` -> `fiscal_year_start_month`
`first_day_of_week` -> `first_day_of_fiscal_week`
and remove the parameter which was ignored, and will be rejected with the new release