### PR TITLE
Remove IANA unrelated release notes for Hyper

### DIFF
--- a/website/docs/releases.md
+++ b/website/docs/releases.md
@@ -38,7 +38,6 @@ In case you are wondering why all our releases start with `0.0`, read [this FAQ 
   * Vostok, Antarctica changed time zones on 2023-12-18.
   * Casey, Antarctica changed time zones five times since 2020.
   * Code and data fixes for Palestine timestamps starting in 2072.
-  * A new data file zonenow.tab for timestamps starting now.
 
 ### 0.0.18441 [January 10, 2024]
 


### PR DESCRIPTION
In the 0.0.18618 [February 7, 2024] release note, there is a note related to zonenow.tab for IANA timezone that is irrelevant for Hyper and it is cleaned up.