### PR TITLE
Document `regexp_replace`

### DIFF
--- a/website/docs/releases.md
+++ b/website/docs/releases.md
@@ -39,6 +39,7 @@ TODO: Update release number (#TODO) in database version [database version 4](hyp
   * Introduced new [database file format version 4](hyper-api/hyper_process#version-4) to support reading and persisting the new 32-bit floats.
   * A `CAST(… AS double precision)` is needed to store such columns in older file formats.
 * Documented the new and improved [database file format version 3](hyper-api/hyper_process#version-3) that was introduced in version 0.0.16123. The new format supports 128-bit numerics. Refer to [Hyper Database Settings](/docs/hyper-api/hyper_process#default_database_version) for more information.
+* Documented the [regexp_replace](sql/scalar_func/string_matching#regex-functions) function which provides substitution of new text for substrings based on POSIX regular expressions.
 
 :::warning
 Queries using `REAL`, `FLOAT4`, or `FLOAT(p)` with `p <= 24` are now treated as 32-bit floating points.

--- a/website/docs/sql/scalar_func/string_matching.md
+++ b/website/docs/sql/scalar_func/string_matching.md
@@ -89,6 +89,21 @@ Some examples:
     'abc' ~ '^a'     → true
     'abc' ~ '(b|d)'  → true
     'abc' ~ '^(b|c)' → false
+    
+## Regular Expression Functions {#regex-functions}
+
+The `regexp_replace` function provides substitution of new text for substrings that match POSIX regular expression patterns. It has the syntax `regexp_replace(source, pattern, replacement[, flags ])`. The `source` string is returned unchanged if there is no match to the pattern. If there is a match, the `source` string is returned with the replacement string substituted for the matching substring. 
+
+The replacement string can contain `\N`, where `N` is `1` through `9`, to indicate that the source substring matching the `N`'th parenthesized subexpression of the pattern should be inserted. Write `\\` if you need to put a literal backslash in the replacement text. 
+
+`pattern` is searched from the beginning of the string. By default, only the first match of the pattern is replaced. If the `g` flag is given, then all matches at or after the start position are replaced. The `i` flag enables case-insensitive matching. Flags can be combined in a single string.
+
+Some examples:
+
+    regexp_replace('foobarbaz', 'b..', 'X') → 'fooXbaz'
+    regexp_replace('foobarbaz', 'b..', 'X', 'g') → 'fooXX'
+    regexp_replace('foobarbaz', 'b(..)', 'X\1Y', 'g') → 'fooXarYXazY'
+    regexp_replace('A PostgreSQL function', 'a|e|i|o|u', 'X', 'gi') → 'X PXstgrXSQL fXnctXXn'
 
 ## Regular Expression Syntax {#regex-syntax}
 


### PR DESCRIPTION
Document the usage of the `regexp_replace` function with examples for enable partners to use it.