### PR TITLE
Fix deployment by downloading lang_docs with curl instead of typescript

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -52,6 +52,10 @@ jobs:
         working-directory: main/website
         run: yarn install --frozen-lockfile
 
+      - name: Install dependencies (upcoming)
+        working-directory: upcoming/website
+        run: yarn install --frozen-lockfile
+
       - name: Download language docs
         working-directory: main/website
         run: yarn ts-node download_links.ts docs_py docs_cxx docs_java
@@ -62,10 +66,6 @@ jobs:
         env:
           GITHUB_ORIGIN: ${{ steps.setup-pages.outputs.origin }}
           GITHUB_BASE_PATH: ${{ steps.setup-pages.outputs.base_path }}
-
-      - name: Install dependencies (upcoming)
-        working-directory: upcoming/website
-        run: yarn install --frozen-lockfile
 
       - name: Build webpage for `upcoming` branch
         working-directory: upcoming/website

--- a/website/download_links.ts
+++ b/website/download_links.ts
@@ -1,33 +1,18 @@
-import https from 'https';
-import fs from 'fs';
 import { config } from './src/config';
+import { spawn } from 'child_process';
 
 function downloadFile(targetPath: string, url: string) {
-    console.log(`Downloading ${url}`);
-    return new Promise<void>(( resolve, reject ) => {
-        const file = fs.createWriteStream(targetPath);
-        const request = https.get(url, function(response) {
-            response.pipe(file);
-    
-            // after download completed close filestream
-            file.on("finish", () => {
-                file.close();
-                console.log("Download Completed");
-                resolve();
-            });
-            file.on('error', (e)=> {
-                file.close();
-                reject(e);
-            });
-        });
-    });
+    const cmd = `curl --output ${targetPath} ${url}`
+    console.log(`Downloading ${url} to ${targetPath}`);
+    console.log(cmd)
+    spawn(cmd, [], { shell: true, stdio: 'inherit' })
 }
 
 async function downloadArtifact(artifactName: string) {
     const url = config.download[artifactName];
     if(!url) throw `Unknown artifact ${artifactName}`
     const fileSuffix = url.split(".").slice(-1);
-    await downloadFile(artifactName + "." + fileSuffix, url)
+    downloadFile(artifactName + "." + fileSuffix, url)
 }
 
 async function doDownloads() {


### PR DESCRIPTION
The download of the lang_docs zip packages with typescript suddenly started failing and we couldn't figure out why. The download itself succeeded, while the downloaded files were empty.

To work around the issue, the downloading script now uses curl to do the actual download. Typescript is still used to generate the curl command line, as the information for the download is only available in typescript.