### PR TITLE
Change license to the Apache 2.0 license

### DIFF
--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -15,6 +15,14 @@ Hyper API is available for Python, C++ and Java supporting Windows, Mac and Linu
 Depending on the language, the installation can be complex.
 This page contains the detailed requirements and installation instructions for all languages.
 
+## License
+
+The Hyper API packages are released under the Apache 2.0 License.
+The exact license text can be found inside the packages, after unzipping.
+The documentation is licensed under the MIT License.
+The [source code of the documentation](https://github.com/tableau/hyper-db) can be found on GitHub.
+
+
 ## Hardware requirements
 
 The Hyper API only supports 64-bit platforms. It has the following minimum hardware requirements:

--- a/website/docs/releases.md
+++ b/website/docs/releases.md
@@ -26,7 +26,7 @@ In case you are wondering why all our releases start with `0.0`, read [this FAQ 
 
 ### Upcoming Release
 
-
+* Hyper API is now available under the Apache 2.0 license.
 
 ### 0.0.19484 [June 6, 2024]
 


### PR DESCRIPTION
In https://github.com/tableau/hyper-db/issues/102, a customer rightfully pointed out, that our license is pretty hard to find, and that it is rather restrictive, which makes it hard to use Hyper API in corporate environments.

This commit rectifies the situation.