### PR TITLE
docs: Remove "Upcoming Release" notes

### DIFF
--- a/website/docs/releases.md
+++ b/website/docs/releases.md
@@ -24,8 +24,6 @@ In case you are wondering why all our releases start with `0.0`, read [this FAQ 
 
 :::
 
-### Upcoming Release
-
 ### 0.0.19691 [July 4, 2024]
 
 * Hyper API is now available under the Apache 2.0 license.


### PR DESCRIPTION
This commit removes the "Upcoming Release" section from the Release Notes. It should only be used on the "upcoming" branch and was erroneously merged into main in 6b9b028.