### PR TITLE
Fix an error in our documentation for the CASE syntax

### DIFF
--- a/website/docs/sql/scalar_func/conditional.md
+++ b/website/docs/sql/scalar_func/conditional.md
@@ -14,13 +14,13 @@ CASE
     WHEN <condition> THEN <result>
     [WHEN ...]
     [ELSE <result>]
-END CASE
+END
 
 CASE <expression>
     WHEN <value> THEN <result>
     [WHEN ...]
     [ELSE <result>]
-END CASE
+END
 ```
 
 In the first variant, each `condition` is an expression that returns


### PR DESCRIPTION
`END CASE` is not recognized by Hyper.