### PR TITLE
@GUS W-17274770 Add OneTrust Cookie Manager; update GA4 ID

### DIFF
--- a/website/_analytics.js
+++ b/website/_analytics.js
@@ -1,0 +1,18 @@
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+
+if (ExecutionEnvironment.canUseDOM) {
+
+    //  OptanonConsentNoticeStart
+
+    const script = document.createElement('script');
+
+    script.src = 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js';
+    script.type = 'text/javascript';
+    script.setAttribute('data-domain-script', '019321c1-4b7e-7313-9372-ddbd938f50ea')
+    script.innerHTML="function OptanonWrapper() { }";
+
+    document.getElementsByTagName('head')[0].appendChild(script);
+
+    // OptanonConsentNoticeStart -->
+
+}

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -133,14 +133,28 @@ const getConfig = async () => {
               items: [
                 {
                 label: 'Legal',
-                href: 'https://www.tableau.com/en-us/legal',
+                href: 'https://www.salesforce.com/company/legal/',
                 },
+                {
+                  label: 'Terms of Service',
+                  href:  'https://www.salesforce.com/company/legal/sfdc-website-terms-of-service/',
+                  },
                 {
                   label: 'Privacy',
                   href: 'https://www.salesforce.com/company/privacy/'
-                }
-              ]
-          
+                },
+                {
+                  label: 'Responsible Disclosure',
+                  href:  'https://www.salesforce.com/company/legal/disclosure/',
+                },
+                {
+                  label: 'Trust',
+                  href:  'https://trust.salesforce.com/',
+                  }, 
+                  {
+                   html:  `<a href="#" data-ignore-geolocation="true" class="optanon-toggle-display" style="color:#FFFFFF">Cookie Preferences</a>`,
+                  }
+              ]       
             },
           ],
           copyright: `Copyright © ${new Date().getFullYear()} Salesforce, Inc. Built with Docusaurus.`,
@@ -167,10 +181,14 @@ const getConfig = async () => {
         [
           '@docusaurus/plugin-google-gtag',
           {
-            trackingID: 'UA-625217-51',
+            trackingID: '469571326',
             anonymizeIP: true,
           },
         ],
+      ],
+
+      clientModules: [
+        require.resolve('./_analytics.js'),
       ],
   };
 }


### PR DESCRIPTION
* Updated gtag ID to use the new GA4 ID for tableau.github.io 
* Updated footer with new privacy links and updated legal link  (points to Salesforce)
* Added `_analytics.js` file  with OneTrust script for tableau.github.io 