### PR TITLE
Minor: Remove the `VERBOSE` option from the `EXPLAIN` page

### DIFF
--- a/website/docs/sql/command/explain.md
+++ b/website/docs/sql/command/explain.md
@@ -12,7 +12,6 @@ where the available `<option>`s are
 
 ```sql_template
 FORMAT <format>
-VERBOSE
 ANALYZE
 OPTIMIZERSTEPS
 ```


### PR DESCRIPTION
As we already removed `EXPLAIN VERBOSE` syntax (but did not remove it completely from the doc)